### PR TITLE
Wall Thermostat support step 1: Decode data works

### DIFF
--- a/maxcube-commandparser.js
+++ b/maxcube-commandparser.js
@@ -200,7 +200,7 @@ function decodeDevice (payload) {
   switch (payload[0]) {
     case 8: deviceType = EQ3MAX_DEV_TYPE_PUSH_BUTTON; break;
     case 11: deviceType = EQ3MAX_DEV_TYPE_THERMOSTAT; deviceStatus = decodeDeviceThermostat (payload); break;
-    case 12: deviceType = EQ3MAX_DEV_TYPE_WALLTHERMOSTAT; break;
+    case 12: deviceType = EQ3MAX_DEV_TYPE_WALLTHERMOSTAT; deviceStatus = decodeDeviceThermostat (payload); break;
     default: deviceType = EQ3MAX_DEV_TYPE_UNKNOWN; break;
   }
 


### PR DESCRIPTION
The wall thermostat can be treated as a normal thermostat when decoding device data. With this ittle patch, we can read out data. Tested and verified it works as expected on my 2 wall thermostats. Part of fixing issue #14 

Output before:

`{ "rf_address": "0ba773" }`

Output after:

`{ "rf_address": "0ba773", "initialized": true, "fromCmd": false, "error": false, "valid": true, "mode": "AUTO", "dst_active": true, "gateway_known": true, "panel_locked": false, "link_error": false, "battery_low": false, "valve": 4, "setpoint": 14, "temp": 0 }`

UPDATE: With this simple change, I can also set temperature and mode correctly and the changes are sent to the connected thermostats automatically. So IMHO this one line change fixes #14 :-)

I am right niw playing around with https://github.com/Bouni/max-cube-protocol/blob/master/L-Message.md to add working temperature readings.for the wall thermostat.